### PR TITLE
fix: CsrfToken::validate_format checking only JWT header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "bouncer"
-version = "0.28.3"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -160,7 +160,7 @@ describe('verify', () => {
     })
 
     it('doesn\'t allow invalid `token` parameters', async () => {
-      let resp = await http.get(`${url}/index.js?token=<img src onerror=alert(document.domain)>`)
+      let resp = await http.get(`${url}/index.js?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.<img src onerror=alert(document.domain)>`)
       expect(resp.status).toBe(400)
     })
   })

--- a/src/http_server/attestation.rs
+++ b/src/http_server/attestation.rs
@@ -47,7 +47,7 @@ pub(super) async fn post(
     headers: HeaderMap,
     body: Json<Body>,
 ) -> Result<impl IntoResponse, StatusCode> {
-    s.validate_csrf_token(&headers)?;
+    s.token_manager.validate_csrf_token(&headers)?;
 
     s.bouncer
         .set_attestation(&body.attestation_id, &body.origin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,7 @@ use {
     tap::TapFallible,
     tokio::signal::unix::{signal, SignalKind},
     tracing::info,
-    wc::geoip::{
-        block::{middleware::GeoBlockLayer, BlockingPolicy},
-        MaxMindResolver,
-    },
+    wc::geoip::MaxMindResolver,
 };
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
# Description

Currently `CsrfToken::validate_format`  validates only JWT headers, but it should validate the whole string. 

## How Has This Been Tested?

Unit and integration

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update