### PR TITLE
fix: add timeouts to external api requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "future"
+version = "0.1.0"
+source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.1#95b9936f0266b0f4fda40bfcce1b0b603e4dd520"
+dependencies = [
+ "pin-project",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,6 +3194,7 @@ version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.7.1#95b9936f0266b0f4fda40bfcce1b0b603e4dd520"
 dependencies = [
  "analytics",
+ "future",
  "geoip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 build = "build.rs"
 
 [dependencies]
-wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.7.1", features = ["geoip", "geoblock", "analytics"] }
+wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.7.1", features = ["geoip", "geoblock", "analytics", "future"] }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+use {
+    anyhow::Context as _,
+    arrayvec::ArrayString,
+    derive_more::{AsRef, From},
+    serde::{Deserialize, Serialize},
+    std::time::Duration,
+    tap::{Tap, TapFallible, TapOptional},
+    tracing::{error, instrument, warn},
+    wc::future::FutureExt as _,
+};
 pub use {
     anyhow::Error,
     async_trait::async_trait,
@@ -5,13 +15,6 @@ pub use {
     event_sink::EventSink,
     project_registry::ProjectRegistry,
     scam_guard::ScamGuard,
-};
-use {
-    arrayvec::ArrayString,
-    derive_more::{AsRef, From},
-    serde::{Deserialize, Serialize},
-    tap::{Tap, TapFallible, TapOptional},
-    tracing::{error, instrument, warn},
 };
 
 pub mod attestation_store;
@@ -100,7 +103,9 @@ impl<'a, I: Infra> Handle<GetVerifyStatus<'a>> for Service<I> {
         let project_data = self
             .project_registry()
             .project_data(cmd.project_id)
+            .with_timeout(Duration::from_secs(10))
             .await
+            .context("ProjectRegistry::project_data timed out")?
             .tap_err(|e| error!("ProjectRegistry::project_data: {e:?}"))?
             .ok_or(GetVerifyStatusError::UnknownProject)
             .tap_err(|_| warn!("Unknown project id"))?;
@@ -179,7 +184,9 @@ impl<'a, I: Infra> Handle<GetAttestation<'a>> for Service<I> {
         let is_scam = self
             .scam_guard()
             .is_scam(&origin)
+            .with_timeout(Duration::from_secs(10))
             .await
+            .context("ScamGuard::is_scam timed out")?
             .map_err(|e| error!("ScamGuard::is_scam: {e:?}"))
             .unwrap_or(IsScam::Unknown);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,9 @@ impl<'a, I: Infra> Handle<GetAttestation<'a>> for Service<I> {
             .is_scam(&origin)
             .with_timeout(Duration::from_secs(10))
             .await
-            .context("ScamGuard::is_scam timed out")?
-            .map_err(|e| error!("ScamGuard::is_scam: {e:?}"))
+            .map_err(|_| error!("ScamGuard::is_scam timed out"))
+            .ok()
+            .and_then(|res| res.map_err(|e| error!("ScamGuard::is_scam: {e:?}")).ok())
             .unwrap_or(IsScam::Unknown);
 
         Ok(Some(Attestation { origin, is_scam }))


### PR DESCRIPTION
# Description

@arein experienced some strange issue when the request to the verify service just hanged indefinitely. Metrics doesn't indicate a problem on the application level, but let's set explicit timeouts to be 100% sure.

## How Has This Been Tested?

CD will test it on staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update