### PR TITLE
fix(cd): fixing the current version deployment

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -1,5 +1,5 @@
 name: ⚙️ Deploy
-run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
+run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version-type }}:${{ inputs.version-tag }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
 
 on:
   workflow_dispatch:
@@ -22,10 +22,19 @@ on:
           - prod
         default: staging
         required: true
-      version:
+      version-type:
         description: "Release Version"
+        type: choice
+        options:
+          - latest
+          - current
+          - manual
+        default: 'latest'
+        required: true
+      version-tag:
+        description: "Release Version Tag (for manual version)"
         type: string
-        default: '-current-'
+        default: ''
 
 concurrency: deploy
 
@@ -38,7 +47,7 @@ permissions:
 jobs:
   get_deployed_version:
     name: Lookup Version
-    if: ${{ !inputs.deploy-app && inputs.version == '-current-' }}
+    if: ${{ inputs.version-type == 'current' }}
     secrets: inherit
     uses: WalletConnect/ci_workflows/.github/workflows/release-get_deployed_version.yml@0.2.4
     with:
@@ -55,13 +64,20 @@ jobs:
     runs-on:
       group: ${{ vars.RUN_GROUP }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Select target version
         id: select_version
         run: |
-          if [ "${{ inputs.deploy-app }}" != "true" ] && [ "${{ inputs.version }}" == "-current-" ]; then
+          if [ "${{ inputs.version-type }}" == "current" ]; then
             echo "version=${{ needs.get_deployed_version.outputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.version-type }}" == "latest" ]; then
+            echo "version=$(git tag | grep -v '^v' | sort --version-sort | tail -n1)" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version-tag }}" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       version: ${{ steps.select_version.outputs.version }}
@@ -76,4 +92,4 @@ jobs:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app }}
       deploy-prod: ${{ inputs.stage == 'prod' }}
-      version: ${{ needs.select_version .outputs.version }}
+      version: ${{ needs.select_version.outputs.version }}


### PR DESCRIPTION
# Description

This PR fixes the latest version deployment by getting the latest tag from the git.
The choice for the `latest`, `current` and manual image tag is added.

Resolves #68 

## How Has This Been Tested?

[Tested on the branch](https://github.com/WalletConnect/verify-server/actions/runs/7877074841/job/21492466354).
## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update