### PR TITLE
fix: refresh token only when necessary

### DIFF
--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -25,11 +25,11 @@ window.addEventListener("message", (event) => {
         })
     })
 })
-// auto reload to refresh token
+// token is valid for 1 hour, refresh every 55 minutes by reloading
 window.addEventListener("load", async () => {
     setInterval(() => {
         window.location.reload()
-    }, 60_000)
+    }, 1000 * 60 * 55)
 })
 
 // notify the SDK that the iframe is ready


### PR DESCRIPTION
# Description

Tokens are valid for [1 hour](https://github.com/WalletConnect/verify-server/blob/main/src/http_server/mod.rs#L276) but we are getting a new one every 60 seconds for no particular reason. Updating to refresh every 55 minutes to reduce load on Verify Server.

[Slack conversation](https://walletconnect.slack.com/archives/C03TFK9BSGJ/p1707836849572289)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update