### PR TITLE
fix: combine requests

### DIFF
--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -8,7 +8,7 @@ use {
     serde::Deserialize,
 };
 
-const SCRIPT: &str = r#"
+pub const SCRIPT: &str = r#"
 // event subscribed by Verify Enclave
 window.addEventListener("message", (event) => {
     const attestationId = event.data
@@ -41,8 +41,8 @@ pub(super) struct Params {
 }
 
 pub(super) async fn get(query: Query<Params>) -> Result<impl IntoResponse, StatusCode> {
-    let token = query.token;
-    if !CsrfToken::validate_format(&token) {
+    let token = &query.token;
+    if !CsrfToken::validate_format(token) {
         return Err(StatusCode::BAD_REQUEST);
     }
 

--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -8,8 +8,7 @@ use {
     serde::Deserialize,
 };
 
-const TEMPLATE: &str = r#"
-const csrfToken = '{token}';
+const SCRIPT: &str = r#"
 // event subscribed by Verify Enclave
 window.addEventListener("message", (event) => {
     const attestationId = event.data
@@ -46,5 +45,8 @@ pub(super) async fn get(query: Query<Params>) -> Result<impl IntoResponse, Statu
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    Ok(Html(TEMPLATE.replacen("{token}", &query.token, 1)))
+    Ok(Html(format!(
+        "const csrfToken = '{}';{}",
+        query.token, SCRIPT
+    )))
 }

--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -41,12 +41,10 @@ pub(super) struct Params {
 }
 
 pub(super) async fn get(query: Query<Params>) -> Result<impl IntoResponse, StatusCode> {
-    if !CsrfToken::validate_format(&query.token) {
+    let token = query.token;
+    if !CsrfToken::validate_format(&token) {
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    Ok(Html(format!(
-        "const csrfToken = '{}';{}",
-        query.token, SCRIPT
-    )))
+    Ok(Html(format!("const csrfToken = '{token}';{SCRIPT}")))
 }

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -35,7 +35,7 @@ use {
         StatusCode,
     },
     serde::{Deserialize, Serialize},
-    std::{convert::Infallible, future::Future, iter, net::SocketAddr, str::Bytes, sync::Arc},
+    std::{convert::Infallible, future::Future, iter, net::SocketAddr, sync::Arc},
     tap::{Pipe, Tap},
     tower_http::cors::{self, CorsLayer},
     tracing::{info, instrument},

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -168,6 +168,10 @@ pub async fn run<S, G>(
     );
 }
 
+fn index_html(token: &str) -> String {
+    format!("<script>const csrfToken = '{token}';{SCRIPT}</script>")
+}
+
 const UNKNOWN_PROJECT_MSG: &str = "Project with the provided ID doesn't exist. Please, ensure \
                                    that the project is registered on cloud.walletconnect.com";
 
@@ -188,7 +192,7 @@ where
         VerifyStatus::Disabled => String::new().into_response(),
         VerifyStatus::Enabled { verified_domains } => {
             let token = s.token_manager.generate_csrf_token()?;
-            let html = format!("<script>const csrfToken = '{token}';{SCRIPT}</script>");
+            let html = index_html(&token);
             let csp = build_content_security_header(verified_domains);
             let headers = [
                 (header::CONTENT_SECURITY_POLICY, csp),


### PR DESCRIPTION
# Description

Combines HTTP requests for performance. Leaving existing `/index.js` endpoint to be removed in subsequent PR, so we don't get errors during deployment. 

Resolves #67 

## How Has This Been Tested?

Not tested. I want to test before merging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update