### PR TITLE
fix(terraform): datalake_bucket_access IAM policy typo

### DIFF
--- a/terraform/ecs/cluster_iam.tf
+++ b/terraform/ecs/cluster_iam.tf
@@ -53,7 +53,7 @@ resource "aws_iam_policy" "datalake_bucket_access" {
         "Sid" : "AllObjectActionsInAnalyticsBucket",
         "Effect" : "Allow",
         "Action" : "s3:*Object",
-        "Resource" : ["arn:aws:s3:::${var.analytics_datalake_bucket_name}/${module.this.name}}/*"]
+        "Resource" : ["arn:aws:s3:::${var.analytics_datalake_bucket_name}/${module.this.name}/*"]
       },
       {
         "Sid" : "AllGenerateDataKeyForAnalyticsBucket",


### PR DESCRIPTION
# Description

This brakes analytics export due to the lack of permission to the correct path.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update