### PR TITLE
fix: remove redundant origin

### DIFF
--- a/src/http_server/index_js.rs
+++ b/src/http_server/index_js.rs
@@ -16,7 +16,7 @@ window.addEventListener("message", (event) => {
     const origin = event.origin
     if (!attestationId) return
     if (attestationId.length !== 64) return
-    fetch(`${window.location.protocol}//${window.location.host}/attestation`, {
+    fetch(`/attestation`, {
         method: "POST",
         body: JSON.stringify({ attestationId, origin }),
         headers: new Headers({ 


### PR DESCRIPTION
# Description

Noticed we are redundantly specifying the origin of the fetch request. But the `fetch()` method accepts a relative URL to the base URL.

Saves on bandwidth and makes the code more readable.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update