### PR TITLE
fix: reduce timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl<'a, I: Infra> Handle<GetVerifyStatus<'a>> for Service<I> {
         let project_data = self
             .project_registry()
             .project_data(cmd.project_id)
-            .with_timeout(Duration::from_secs(10))
+            .with_timeout(Duration::from_secs(1))
             .await
             .context("ProjectRegistry::project_data timed out")?
             .tap_err(|e| error!("ProjectRegistry::project_data: {e:?}"))?


### PR DESCRIPTION
# Description

Reduce registry call timeout. This should always respond within 1s and if it doesn't something is off.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update